### PR TITLE
Move provider classes out of implementation package

### DIFF
--- a/src/main/java/com/gluonhq/connect/provider/BaseRestProvider.java
+++ b/src/main/java/com/gluonhq/connect/provider/BaseRestProvider.java
@@ -24,7 +24,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.gluonhq.impl.connect.provider;
+package com.gluonhq.connect.provider;
 
 import com.gluonhq.connect.source.RestDataSource;
 

--- a/src/main/java/com/gluonhq/connect/provider/RestClient.java
+++ b/src/main/java/com/gluonhq/connect/provider/RestClient.java
@@ -32,9 +32,6 @@ import com.gluonhq.connect.converter.InputStreamIterableInputConverter;
 import com.gluonhq.connect.converter.OutputStreamOutputConverter;
 import com.gluonhq.connect.source.RestDataSource;
 import com.gluonhq.connect.MultiValuedMap;
-import com.gluonhq.impl.connect.provider.RestListDataReader;
-import com.gluonhq.impl.connect.provider.RestObjectDataReader;
-import com.gluonhq.impl.connect.provider.RestObjectDataWriterAndRemover;
 
 /**
  * <p>The RestClient assists in using the {@link DataProvider} with HTTP URLs as the data source. For instance, to read

--- a/src/main/java/com/gluonhq/connect/provider/RestListDataReader.java
+++ b/src/main/java/com/gluonhq/connect/provider/RestListDataReader.java
@@ -24,12 +24,11 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.gluonhq.impl.connect.provider;
+package com.gluonhq.connect.provider;
 
 import com.gluonhq.connect.GluonObservableList;
 import com.gluonhq.connect.converter.InputStreamIterableInputConverter;
 import com.gluonhq.connect.converter.JsonIterableInputConverter;
-import com.gluonhq.connect.provider.ListDataReader;
 import com.gluonhq.connect.source.RestDataSource;
 
 import java.io.IOException;

--- a/src/main/java/com/gluonhq/connect/provider/RestObjectDataReader.java
+++ b/src/main/java/com/gluonhq/connect/provider/RestObjectDataReader.java
@@ -24,14 +24,13 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.gluonhq.impl.connect.provider;
+package com.gluonhq.connect.provider;
 
 import com.gluonhq.connect.GluonObservableObject;
 import com.gluonhq.connect.converter.InputStreamInputConverter;
 import com.gluonhq.connect.converter.JsonInputConverter;
 import com.gluonhq.connect.converter.StringInputConverter;
 import com.gluonhq.connect.converter.VoidInputConverter;
-import com.gluonhq.connect.provider.ObjectDataReader;
 import com.gluonhq.connect.source.RestDataSource;
 
 import java.io.IOException;

--- a/src/main/java/com/gluonhq/connect/provider/RestObjectDataWriterAndRemover.java
+++ b/src/main/java/com/gluonhq/connect/provider/RestObjectDataWriterAndRemover.java
@@ -24,7 +24,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package com.gluonhq.impl.connect.provider;
+package com.gluonhq.connect.provider;
 
 import com.gluonhq.connect.GluonObservableObject;
 import com.gluonhq.connect.converter.InputStreamInputConverter;
@@ -32,8 +32,6 @@ import com.gluonhq.connect.converter.JsonOutputConverter;
 import com.gluonhq.connect.converter.OutputStreamOutputConverter;
 import com.gluonhq.connect.converter.StringOutputConverter;
 import com.gluonhq.connect.converter.VoidOutputConverter;
-import com.gluonhq.connect.provider.ObjectDataRemover;
-import com.gluonhq.connect.provider.ObjectDataWriter;
 import com.gluonhq.connect.source.RestDataSource;
 
 import java.io.IOException;


### PR DESCRIPTION
In a modular scenario, we need the provider classes out of implementation package.